### PR TITLE
fix: remove push trigger from GHA

### DIFF
--- a/.github/workflows/ko.yml
+++ b/.github/workflows/ko.yml
@@ -1,6 +1,6 @@
 ---
 name: Ko
-on: [push, pull_request, create]  # create is for tags
+on: [pull_request, create]  # create is for tags
 
 jobs:
   build:


### PR DESCRIPTION
All commits to a PR are getting the same ko build check done 2x. Since we have branch protection rules in place, we don't need the `push` check.